### PR TITLE
Enforce utf8 text in api_type_cache

### DIFF
--- a/SQL/tables_layouts.sql
+++ b/SQL/tables_layouts.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `api_type_cache` (
   `keyv` varchar(255) NOT NULL,
   `type` tinyint(1) NOT NULL,
   UNIQUE KEY `keyv` (`keyv`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `api_cache` (
   `apicall` varchar(80) default NULL,


### PR DESCRIPTION
Debian is defaulting to a 4-byte character, which means a VARCHAR(255) is too long to be a primary key.